### PR TITLE
feat: add goose CLI v1.28.0 to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.n
     zsh \
     ripgrep \
     ca-certificates \
+    bzip2 \
     python3.12 && \
     yum copr enable -y atim/starship && \
     yum install -y starship && \
@@ -40,6 +41,28 @@ RUN uv venv /opt/aider_chat_venv --python 3.12 \
 
 # Add the bin directories of both virtual environments to the PATH
 ENV PATH="/opt/ra_aid_venv/bin:/opt/aider_chat_venv/bin:${PATH}"
+
+# Install Goose
+ENV GOOSE_VERSION=v1.28.0
+RUN mkdir -p /opt/goose-install && \
+    curl -L -o /opt/goose-install/goose.tar.bz2 \
+    https://github.com/block/goose/releases/download/${GOOSE_VERSION}/goose-x86_64-unknown-linux-gnu.tar.bz2 && \
+    tar -xjf /opt/goose-install/goose.tar.bz2 -C /opt/goose-install && \
+    mv /opt/goose-install/goose /usr/local/bin/goose && \
+    chmod +x /usr/local/bin/goose && \
+    rm -rf /opt/goose-install
+
+# Pre-configure Paths & Permissions
+# We pre-create the nested folders Goose expects to avoid "Permission Denied"
+# when they try to mkdir at runtime.
+RUN mkdir -p \
+    /home/user/.local/bin \
+    /home/user/.local/share/goose \
+    /home/user/.local/state/goose/logs \
+    /home/user/.config/goose \
+    /home/user/.cache/goose && \
+    chown -R 10001:0 /home/user/.local && \
+    chmod -R g=u /home/user
 
 # Install chectl
 RUN curl -Lo /usr/local/bin/chectl https://che-incubator.github.io/chectl/install.sh && \

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This environment is supercharged with powerful command-line AI tools to streamli
 
 - **Aider (`aider`)**: Your AI pair-programming partner in the terminal. Aider works with local git repositories, allowing you to ask for new features, write tests, or refactor code, and it will apply the changes directly to your files.
 - **RA.Aid (`ra-aid`)**: An open-source AI assistant that combines research, planning, and implementation to help you build software faster and smarter.
+- **Goose (`goose`)**: An AI-powered developer agent that can help you with coding tasks, debugging, and general software development workflows right from your terminal.
 
 ## Base Image
 


### PR DESCRIPTION
## Description

Install Block goose CLI with proper permissions and dependencies:
- Add `bzip2` package required for tarball extraction
- Download and install goose from official release (v1.28.0)
- Move binary to `/usr/local/bin` for system-wide access
- Create goose config/data directories with correct permissions for user 10001

## How to test?

You can test it by creating a workspace based on this [branch](https://github.com/rohankanojia-forks/cli-ai-tools/tree/pr/add-goose-cli-testing)

## Demo


https://github.com/user-attachments/assets/99fc5ab6-09e5-454b-b890-1b963324c93c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container image updated to include Goose v1.28.0 and required system dependency for archive handling.
  * Runtime directories for Goose pre-created with adjusted ownership and permissions to prevent runtime failures.
* **Documentation**
  * README updated to document the new Goose tooling addition and basic usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->