### PR TITLE
feat : add opencode cli v1.3.13 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,17 @@ RUN mkdir -p /opt/goose-install && \
     tar -xjf /opt/goose-install/goose.tar.bz2 -C /opt/goose-install && \
     mv /opt/goose-install/goose /usr/local/bin/goose && \
     chmod +x /usr/local/bin/goose && \
-    rm -rf /opt/goose-install
+    rm -rf /opt/goose-install 
+
+# Install OpenCode
+ENV OPENCODE_VERSION=v1.3.13
+RUN mkdir -p /opt/opencode-install && \
+    curl -L -o /opt/opencode-install/opencode.tar.gz \
+    https://github.com/anomalyco/opencode/releases/download/${OPENCODE_VERSION}/opencode-linux-x64.tar.gz && \
+    tar -xzf /opt/opencode-install/opencode.tar.gz -C /opt/opencode-install && \
+    mv /opt/opencode-install/opencode /usr/local/bin/opencode && \
+    chmod +x /usr/local/bin/opencode && \
+    rm -rf /opt/opencode-install 
 
 # Pre-configure Paths & Permissions
 # We pre-create the nested folders Goose expects to avoid "Permission Denied"


### PR DESCRIPTION
## Description

This is part of Devtools week https://github.com/eclipse-che/che/issues/23749

Install [opencode CLI](https://opencode.ai/) from github release and add it to `/usr/local/bin`

There is also vscode extension for opencode (shown in demo video), it also relies on `opencode` binary. `opencode`  comes with a set of free models that you can use without creating an account. It's also possible to configure your own LLM provider using `/connect` and provide API key.


https://github.com/user-attachments/assets/8e389b19-4316-4f66-aff9-59352c461bf5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configuration to include `opencode` binary (v1.3.13) pre-installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->